### PR TITLE
Add workaround for security group limitation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,19 @@ resource "aws_security_group" "sg" {
   vpc_id = var.vpc_id
 }
 
+resource "aws_security_group_rule" "allow_sg" {
+  count = length(var.allow_from_sgs)
+
+  type      = "ingress"
+  from_port = aws_rds_cluster.cluster.port
+  to_port   = aws_rds_cluster.cluster.port
+  protocol  = "tcp"
+
+  source_security_group_id = var.allow_from_sgs[count.index]
+  security_group_id        = aws_security_group.sg.id
+}
+
+// DEPRECATED
 resource "aws_security_group_rule" "sg_ingress" {
   type      = "ingress"
   from_port = aws_rds_cluster.cluster.port
@@ -82,6 +95,7 @@ resource "aws_security_group_rule" "sg_ingress" {
   source_security_group_id = aws_security_group.intra.id
 }
 
+// DEPRECATED
 resource "aws_security_group" "intra" {
   tags = merge(
     local.tags,

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "sg" {
 }
 
 output "sg_intra" {
-  description = "Security group allowed for access"
+  description = "DEPRECATED: Security group allowed for access"
   value       = aws_security_group.intra.id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,8 @@ variable "instances" {
   }))
   default = {}
 }
+
+variable "allow_from_sgs" {
+  description = "a list of security groups for which ingress rules are created"
+  default     = []
+}


### PR DESCRIPTION
There are only 5 security groups allowed per EC2 instance.
This causes a problem when we have to add the `intra_sg` to our ECS EC2s for each database we create.
This PR deprecates `intra_sg` and introduces `allow_from_sgs`.
Instead of adding a security group to every resource that needs access, we'll add the security groups of those resources to the list of security groups that is allowed to have access.