### PR TITLE
SES-2772-serverless: add rds mode: serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ module "my_db_cluster" {
 #### Aurora Serverless
 ```hcl
 module "serverless" {
-  source = "github.com/ryte/INF-tf-rds.git?ref=v0.2.2"
+  source = "github.com/ryte/INF-tf-rds.git?ref=v0.5.1"
   tags                     = "${local.common_tags}"
   domain                   = "${local.domain}"
   name                     = "my_db_cluster_name"
@@ -235,13 +235,13 @@ module "serverless" {
   vpc_id                   = "${data.terraform_remote_state.vpc.vpc_id}"
   subnet_ids               = "${data.terraform_remote_state.vpc.subnet_private}"
   apply_immediately        = true
-  availability_zones       = ["a", "b", "c"]
   backtrack_window         = 0
   backup_retention_period  = 30
   auto_pause               = true
   max_capacity             = 2
   min_capacity             = 1
   seconds_until_auto_pause = 300
+  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.custom_serverless.name
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -225,15 +225,15 @@ module "my_db_cluster" {
 ```hcl
 module "serverless" {
   source = "github.com/ryte/INF-tf-rds.git?ref=v0.5.1"
-  tags                     = "${local.common_tags}"
-  domain                   = "${local.domain}"
+  tags                     = local.common_tags
+  domain                   = local.domain
   name                     = "my_db_cluster_name"
   engine                   = "aurora"
   engine_mode              = "serverless"
   engine_version           = "5.6.10a"
-  master_credentials       = "${local.authentication_db_credentials}"
-  vpc_id                   = "${data.terraform_remote_state.vpc.vpc_id}"
-  subnet_ids               = "${data.terraform_remote_state.vpc.subnet_private}"
+  master_credentials       = local.authentication_db_credentials
+  vpc_id                   = data.terraform_remote_state.vpc.vpc_id
+  subnet_ids               = data.terraform_remote_state.vpc.subnet_private
   apply_immediately        = true
   backtrack_window         = 0
   backup_retention_period  = 30

--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ provider "mysql" {
 
 ## Changelog
 
+- 0.2.2 - Added serverless engine_mode
 - 0.5.0 - Add `allow_from_sgs` to work around "5 security groups per EC2"-limit (deprecates `intra_sg`)
 - 0.4.1 - Set cost allocation tags
 - 0.4.0 - use map instead of list for instance config and use data for availibility zones now

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ module "my_db_cluster" {
 ```hcl
 module "serverless" {
   source = "github.com/ryte/INF-tf-rds.git?ref=v0.5.1"
+
   tags                     = local.common_tags
   domain                   = local.domain
   name                     = "my_db_cluster_name"
@@ -311,6 +312,7 @@ module "serverless" {
   max_capacity             = 2
   min_capacity             = 1
   seconds_until_auto_pause = 300
+
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.custom_serverless.name
 }
 ```

--- a/README.md
+++ b/README.md
@@ -221,6 +221,30 @@ module "my_db_cluster" {
 }
 ```
 
+#### Aurora Serverless
+```hcl
+module "serverless" {
+  source = "github.com/ryte/INF-tf-rds.git?ref=v0.2.2"
+  tags                     = "${local.common_tags}"
+  domain                   = "${local.domain}"
+  name                     = "my_db_cluster_name"
+  engine                   = "aurora"
+  engine_mode              = "serverless"
+  engine_version           = "5.6.10a"
+  master_credentials       = "${local.authentication_db_credentials}"
+  vpc_id                   = "${data.terraform_remote_state.vpc.vpc_id}"
+  subnet_ids               = "${data.terraform_remote_state.vpc.subnet_private}"
+  apply_immediately        = true
+  availability_zones       = ["a", "b", "c"]
+  backtrack_window         = 0
+  backup_retention_period  = 30
+  auto_pause               = true
+  max_capacity             = 2
+  min_capacity             = 1
+  seconds_until_auto_pause = 300
+}
+```
+
 ### Master user credentials
 
 To not write the credentials in git, we use `random_id` and `random_password`.
@@ -371,7 +395,7 @@ provider "mysql" {
 
 ## Changelog
 
-- 0.2.2 - Added serverless engine_mode
+- 0.5.1 - Added serverless engine_mode
 - 0.5.0 - Add `allow_from_sgs` to work around "5 security groups per EC2"-limit (deprecates `intra_sg`)
 - 0.4.1 - Set cost allocation tags
 - 0.4.0 - use map instead of list for instance config and use data for availibility zones now

--- a/README.md
+++ b/README.md
@@ -10,45 +10,68 @@ and currently maintained by the [INF](https://github.com/orgs/ryte/teams/inf).
 
 The following requirements are needed by this module:
 
-- terraform (>= 0.12)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 0.12)
 
 ## Providers
 
 The following providers are used by this module:
 
-- aws
+- <a name="provider_aws"></a> [aws](#provider\_aws)
 
-- random
+- <a name="provider_random"></a> [random](#provider\_random)
+
+## Modules
+
+No modules.
+
+## Resources
+
+The following resources are used by this module:
+
+- [aws_db_subnet_group.sng](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) (resource)
+- [aws_rds_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) (resource)
+- [aws_rds_cluster.serverless](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) (resource)
+- [aws_rds_cluster_instance.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) (resource)
+- [aws_route53_record.reader](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) (resource)
+- [aws_route53_record.writer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) (resource)
+- [aws_security_group.intra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) (resource)
+- [aws_security_group.sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) (resource)
+- [aws_security_group_rule.allow_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) (resource)
+- [aws_security_group_rule.sg_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) (resource)
+- [random_id.final_snapshot](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) (resource)
+- [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) (data source)
+- [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) (data source)
+- [aws_route53_zone.zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) (data source)
 
 ## Required Inputs
 
 The following input variables are required:
 
-### domain
+### <a name="input_domain"></a> [domain](#input\_domain)
 
 Description: Domain in which the FQDNs are created
 
 Type: `any`
 
-### master\_credentials
+### <a name="input_master_credentials"></a> [master\_credentials](#input\_master\_credentials)
 
 Description: Username and password for master user (see [Master user credentials](#master-user-credentials))
 
 Type: `map(string)`
 
-### name
+### <a name="input_name"></a> [name](#input\_name)
 
 Description: Cluster name and instance name prefix (also used to generate FQDNs)
 
 Type: `any`
 
-### subnet\_ids
+### <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids)
 
 Description: Subnets for the Aurora RDS (should be private subnet)
 
 Type: `list(string)`
 
-### vpc\_id
+### <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id)
 
 Description: VPC id the subnets will be defined in
 
@@ -58,7 +81,7 @@ Type: `any`
 
 The following input variables are optional (have default values):
 
-### allow\_from\_sgs
+### <a name="input_allow_from_sgs"></a> [allow\_from\_sgs](#input\_allow\_from\_sgs)
 
 Description: a list of security groups for which ingress rules are created
 
@@ -66,7 +89,7 @@ Type: `list`
 
 Default: `[]`
 
-### apply\_immediately
+### <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately)
 
 Description: Specifies whether any cluster modifications are applied immediately, or during the next maintenance window
 
@@ -74,7 +97,15 @@ Type: `bool`
 
 Default: `false`
 
-### backtrack\_window
+### <a name="input_auto_pause"></a> [auto\_pause](#input\_auto\_pause)
+
+Description: Whether to enable automatic pause. A DB cluster can be paused only when it's idle (it has no connections).
+
+Type: `bool`
+
+Default: `false`
+
+### <a name="input_backtrack_window"></a> [backtrack\_window](#input\_backtrack\_window)
 
 Description: The target backtrack window, in seconds. Only available for aurora engine currently (as of 2018-11-06)
 
@@ -82,7 +113,7 @@ Type: `number`
 
 Default: `0`
 
-### backup\_retention\_period
+### <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period)
 
 Description: Days to keep backups
 
@@ -90,7 +121,7 @@ Type: `number`
 
 Default: `30`
 
-### cloudwatch\_log\_types
+### <a name="input_cloudwatch_log_types"></a> [cloudwatch\_log\_types](#input\_cloudwatch\_log\_types)
 
 Description: Log types to write to cloudwatch (audit, error, general, slowquery)
 
@@ -104,7 +135,15 @@ Default:
 ]
 ```
 
-### engine
+### <a name="input_db_cluster_parameter_group_name"></a> [db\_cluster\_parameter\_group\_name](#input\_db\_cluster\_parameter\_group\_name)
+
+Description: A cluster parameter group to associate with the cluster.
+
+Type: `string`
+
+Default: `""`
+
+### <a name="input_engine"></a> [engine](#input\_engine)
 
 Description: Aurora RDS engine (aurora-mysql or aurora-postgresql)
 
@@ -112,7 +151,15 @@ Type: `string`
 
 Default: `"aurora-mysql"`
 
-### engine\_version
+### <a name="input_engine_mode"></a> [engine\_mode](#input\_engine\_mode)
+
+Description: The database engine mode. Defaults to: provisioned, set to serverless if you want to create rds-serverless
+
+Type: `string`
+
+Default: `"provisioned"`
+
+### <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version)
 
 Description: Version of the DB engine
 
@@ -120,7 +167,7 @@ Type: `string`
 
 Default: `"5.7.12"`
 
-### instances
+### <a name="input_instances"></a> [instances](#input\_instances)
 
 Description: priority and type of instances (see [Instance configuration](#instance-configuration))
 
@@ -135,7 +182,23 @@ map(object({
 
 Default: `{}`
 
-### performance\_insights\_enabled
+### <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity)
+
+Description: The maximum capacity for an Aurora DB cluster in serverless DB engine mode.
+
+Type: `number`
+
+Default: `2`
+
+### <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity)
+
+Description: The minimum capacity for an Aurora DB cluster in serverless DB engine mode.
+
+Type: `number`
+
+Default: `1`
+
+### <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled)
 
 Description: Enable performance insights
 
@@ -143,7 +206,7 @@ Type: `bool`
 
 Default: `true`
 
-### preferred\_backup\_window
+### <a name="input_preferred_backup_window"></a> [preferred\_backup\_window](#input\_preferred\_backup\_window)
 
 Description: The daily time range (UTC) during which automated backups are created if automated backups are enabled
 
@@ -151,7 +214,7 @@ Type: `string`
 
 Default: `"00:00-02:00"`
 
-### preferred\_maintenance\_window
+### <a name="input_preferred_maintenance_window"></a> [preferred\_maintenance\_window](#input\_preferred\_maintenance\_window)
 
 Description: The weekly time range (UTC) during which system maintenance can occur
 
@@ -159,7 +222,15 @@ Type: `string`
 
 Default: `"Mon:02:00-Mon:04:00"`
 
-### tags
+### <a name="input_seconds_until_auto_pause"></a> [seconds\_until\_auto\_pause](#input\_seconds\_until\_auto\_pause)
+
+Description: The time, in seconds, before an Aurora DB cluster in serverless mode is paused.
+
+Type: `number`
+
+Default: `300`
+
+### <a name="input_tags"></a> [tags](#input\_tags)
 
 Description: common tags to add to the ressources
 
@@ -171,30 +242,29 @@ Default: `{}`
 
 The following outputs are exported:
 
-### cluster\_arn
+### <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn)
 
 Description: Aurora RDS cluster ARN
 
-### cluster\_port
+### <a name="output_cluster_port"></a> [cluster\_port](#output\_cluster\_port)
 
 Description: Database port
 
-### reader\_fqdn
+### <a name="output_reader_fqdn"></a> [reader\_fqdn](#output\_reader\_fqdn)
 
 Description: Domain name for reader endpoint
 
-### sg
+### <a name="output_sg"></a> [sg](#output\_sg)
 
 Description: Security group for database
 
-### sg\_intra
+### <a name="output_sg_intra"></a> [sg\_intra](#output\_sg\_intra)
 
 Description: DEPRECATED: Security group allowed for access
 
-### writer\_fqdn
+### <a name="output_writer_fqdn"></a> [writer\_fqdn](#output\_writer\_fqdn)
 
 Description: Domain name for writer endpoint
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Usage
 
@@ -395,7 +465,7 @@ provider "mysql" {
 
 ## Changelog
 
-- 0.5.1 - Added serverless engine_mode
+- 0.5.1 - Add `engine_mode` with serverless (default is provisioned)
 - 0.5.0 - Add `allow_from_sgs` to work around "5 security groups per EC2"-limit (deprecates `intra_sg`)
 - 0.4.1 - Set cost allocation tags
 - 0.4.0 - use map instead of list for instance config and use data for availibility zones now

--- a/dns.tf
+++ b/dns.tf
@@ -6,7 +6,7 @@ resource "aws_route53_record" "writer" {
   name = "${var.name}-db-write.${var.domain}."
 
   records = [
-    aws_rds_cluster.cluster.endpoint,
+    var.engine_mode != "serverless" ? join(",", aws_rds_cluster.cluster.*.endpoint) : join(",", aws_rds_cluster.serverless.*.endpoint),
   ]
 
   ttl     = "60"
@@ -15,10 +15,11 @@ resource "aws_route53_record" "writer" {
 }
 
 resource "aws_route53_record" "reader" {
-  name = "${var.name}-db-read.${var.domain}."
+  count = var.engine_mode != "serverless" ? 1 : 0
+  name  = "${var.name}-db-read.${var.domain}."
 
   records = [
-    aws_rds_cluster.cluster.reader_endpoint,
+    aws_rds_cluster.cluster[0].reader_endpoint,
   ]
 
   ttl     = "60"

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 data "aws_availability_zones" "available" {}
 
 resource "aws_rds_cluster_instance" "instance" {
-  for_each = var.engine_mode != "serverless" ? length(var.instances) : 0
+  for_each = var.engine_mode != "serverless" ? var.instances : {}
 
   tags                         = merge(local.tags, { type = "db" })
   cluster_identifier           = aws_rds_cluster.cluster[0].id

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "aws_rds_cluster_instance" "instance" {
   for_each = var.engine_mode != "serverless" ? length(var.instances) : 0
 
   tags                         = merge(local.tags, { type = "db" })
-  cluster_identifier           = aws_rds_cluster.cluster.id
+  cluster_identifier           = aws_rds_cluster.cluster[0].id
   identifier                   = "${var.name}-${each.key}"
   engine                       = var.engine
   engine_version               = var.engine_version

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "writer_fqdn" {
 
 output "reader_fqdn" {
   description = "Domain name for reader endpoint"
-  value       = aws_route53_record.reader.fqdn
+  value       = join(",", aws_route53_record.reader.*.fqdn)
 }
 
 output "sg" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,10 +20,10 @@ output "sg_intra" {
 
 output "cluster_arn" {
   description = "Aurora RDS cluster ARN"
-  value       = aws_rds_cluster.cluster.arn
+  value       = var.engine_mode != "serverless" ? join(",", aws_rds_cluster.cluster.*.arn) : join(",", aws_rds_cluster.serverless.*.arn)
 }
 
 output "cluster_port" {
   description = "Database port"
-  value       = aws_rds_cluster.cluster.port
+  value       = var.engine_mode != "serverless" ? join(",", aws_rds_cluster.cluster.*.arn) : join(",", aws_rds_cluster.serverless.*.arn)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,23 @@ variable "allow_from_sgs" {
   description = "a list of security groups for which ingress rules are created"
   default     = []
 }
+
+variable "engine_mode" {
+  default = "provisioned"
+}
+
+variable "auto_pause" {
+  default = "false"
+}
+
+variable "max_capacity" {
+  default = 2
+}
+
+variable "min_capacity" {
+  default = 1
+}
+
+variable "seconds_until_auto_pause" {
+  default = 300
+}

--- a/variables.tf
+++ b/variables.tf
@@ -87,25 +87,31 @@ variable "allow_from_sgs" {
 }
 
 variable "engine_mode" {
-  default = "provisioned"
+  description = "The database engine mode. Defaults to: provisioned, set to serverless if you want to create rds-serverless"
+  default     = "provisioned"
 }
 
 variable "auto_pause" {
-  default = "false"
+  description = "Whether to enable automatic pause. A DB cluster can be paused only when it's idle (it has no connections)."
+  default     = false
 }
 
 variable "max_capacity" {
-  default = 2
+  description = "The maximum capacity for an Aurora DB cluster in serverless DB engine mode."
+  default     = 2
 }
 
 variable "min_capacity" {
-  default = 1
+  description = "The minimum capacity for an Aurora DB cluster in serverless DB engine mode."
+  default     = 1
 }
 
 variable "seconds_until_auto_pause" {
-  default = 300
+  description = "The time, in seconds, before an Aurora DB cluster in serverless mode is paused."
+  default     = 300
 }
 
 variable "db_cluster_parameter_group_name" {
-  default = ""
+  description = "A cluster parameter group to associate with the cluster."
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -105,3 +105,7 @@ variable "min_capacity" {
 variable "seconds_until_auto_pause" {
   default = 300
 }
+
+variable "db_cluster_parameter_group_name" {
+  default = ""
+}


### PR DESCRIPTION
- Based on the ticket [SES-2772](https://ryte.atlassian.net/browse/SES-2772): To migrate to terraform 0.12, need to add rds-serverless to this module
  - add condition: `var.engine_mode == "serverless"` to create `rds-serverless`
